### PR TITLE
Add option to disable file operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,13 +65,13 @@ const makeNewHashedFiles = async ({
         console.error(error)
       );
       await del([oldFilePath], delOptions).catch(error => console.error(error));
-      debug &&
+    }
+    debug &&
       console.debug(
         `Renamed '${oldFilePath}' to '${newFilePath}' (delOptions '${JSON.stringify(
           delOptions
         )}')`
       );
-    }
     newJson[oldNonHash] = getNewFilename(oldHash);
   }
   return newJson;


### PR DESCRIPTION
With this option, the manifest will be rewritten, but files on disk are not actually deleted or renamed. This might be useful for debugging, sort of a `--dry-run` scenario with only the manifest being affected. Look, I'm grasping at straws here.

What we _actually_ need it for in our case is that we don't want to manually delete old asset files every time we make a deployment (which unfortunately is completely manual). So we have added a `RewriteRule` to our Apache configuration that will rewrite these versioned filenames to the original filenames. That way we still get cache-busting on our CDN, but we keep the original filenames.
Pretty questionable, definitely abusable and I would not recommend doing it this way. Unfortunately that's what we're stuck with. 